### PR TITLE
add "getClickType" method

### DIFF
--- a/src/LogansGreatButton.h
+++ b/src/LogansGreatButton.h
@@ -9,7 +9,16 @@ Created by Logan Krantz 2016/10/15.
 
 #ifndef LogansGreatButton_h
 #define LogansGreatButton_h
-
+#define _ActionPressed 1
+#define _PressShortRelease 2
+#define _PressLongStart 3
+#define _PressLongRelease 4
+#define _HoldStart 5
+#define _HoldContinuous 6
+#define _HoldRelease 7
+#define _MultiClicks 8
+#define _ShiftStart 9
+#define _ShiftRelease 10
 #include <Arduino.h>
 typedef void(*callBack)();
 
@@ -25,8 +34,7 @@ extern void onButtonHoldRelease();
 extern void onMultiClicks();
 extern void onButtonShiftStart();
 extern void onButtonShiftRelease();
-
-
+extern void getClickType();
 
 
 
@@ -92,7 +100,7 @@ public:
 
 	// Returns the current number of multiclicks
 	uint16_t getNumberOfMultiClicks();
-	
+	unsigned int getClickType();
 
 private:
 	//void interruptButton();


### PR DESCRIPTION
Thank you very much for the button library you wrote, he helped me a lot, but I found a problem in using it. There are too many callback functions added for button events, so I modified the library and added a new method to it. After this method is called, it will return the type of key trigger, so, we can add the same function for all key events, and then determine the type of event in the function to react, so that there is no need to write different event functions for different event types. Off,
Sorry my English is not very good :) From google translation
befor:[befor1.png](https://postimg.cc/GHMn8VCS) [befor2.png](https://postimg.cc/fVp45dkc)
after:[after1.png](https://postimg.cc/yWPwttkY) [after2.png](https://postimg.cc/Hr7vYhsM)
